### PR TITLE
Use new domain name for API end-point

### DIFF
--- a/lib/wipco/client.rb
+++ b/lib/wipco/client.rb
@@ -5,7 +5,7 @@ require "wipco"
 require "wipco/auth"
 require "byebug"
 class Wipco::Client
-  API_ENDPOINT = "https://wip.chat/graphql"
+  API_ENDPOINT = "https://wip.co/graphql"
 
   attr_reader :api_key, :json, :response
 


### PR DESCRIPTION
The old domain name (`wip.chat`) is deprecated.